### PR TITLE
Bump @truffle/hdwallet-provider to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/truffle-box/polygon-box#readme",
   "devDependencies": {
     "@maticnetwork/maticjs": "^2.0.40",
-    "@truffle/hdwallet-provider": "^1.2.3",
+    "@truffle/hdwallet-provider": "^1.4.0",
     "dotenv": "^9.0.0"
   },
   "dependencies": {}


### PR DESCRIPTION
See issue #1 and related issues linked below. 

Fixes below error when attempting to migrate the default contract.

```
Error: while migrating SimpleStorage: only replay-protected (EIP-155) transactions allowed over RPC
```

https://github.com/trufflesuite/truffle/issues/3913
https://github.com/trufflesuite/truffle/issues/4147